### PR TITLE
Add some mods and a mod menu config

### DIFF
--- a/config/modmenu.json
+++ b/config/modmenu.json
@@ -1,0 +1,32 @@
+{
+  "sorting": "ascending",
+  "count_libraries": true,
+  "compact_list": false,
+  "count_children": true,
+  "mods_button_style": "classic",
+  "game_menu_button_style": "replace_bugs",
+  "count_hidden_mods": true,
+  "mod_count_location": "title_screen",
+  "hide_mod_links": false,
+  "show_libraries": false,
+  "hide_mod_license": false,
+  "hide_badges": false,
+  "hide_mod_credits": false,
+  "easter_eggs": true,
+  "modify_title_screen": true,
+  "modify_game_menu": true,
+  "hide_config_buttons": false,
+  "random_java_colors": false,
+  "translate_names": true,
+  "translate_descriptions": true,
+  "config_mode": false,
+  "disable_drag_and_drop": false,
+  "hidden_mods": [
+    "minecraft"
+  ],
+  "hidden_configs": [],
+  "disable_update_checker": [],
+  "update_checker": true,
+  "button_update_badge": true,
+  "quick_configure": true
+}

--- a/index.toml
+++ b/index.toml
@@ -13,6 +13,10 @@ file = "config/immediatelyfast.json"
 hash = "42b8328d9c958aa8adca9a9fc62d0deb154e4a411ba55e984211f6e673ad2d58"
 
 [[files]]
+file = "config/modmenu.json"
+hash = "99e37f421f65527d18d572cdefbfaddc05073a4aacc9d0efe4adcbb2b619a661"
+
+[[files]]
 file = "config/regions_unexplored.conf"
 hash = "92a8c624dbaab0a037426de0ee83f8a6c1ca1e2ad104063b201af9e222da4fec"
 
@@ -79,6 +83,16 @@ hash = "cc42b5f7578a8cc561e5a94a1885e12e32d7570f1bb452b62365405e94a8981b"
 metafile = true
 
 [[files]]
+file = "mods/ctrl-q.pw.toml"
+hash = "ad2462959438c5181844602ff8489ff7397d87bf7dd1f42b6f9838cd66fc7bc9"
+metafile = true
+
+[[files]]
+file = "mods/dark-graph.pw.toml"
+hash = "81a898a3c243519b8676f2b254d66b814d7598ff5e2916972ece6ce34d3c57c2"
+metafile = true
+
+[[files]]
 file = "mods/dungeons-and-taverns.pw.toml"
 hash = "26567686c9226eb0c6fe19fa01047275563b72c5bf26ab1f55f8c3fa2e624df2"
 metafile = true
@@ -91,6 +105,11 @@ metafile = true
 [[files]]
 file = "mods/emi.pw.toml"
 hash = "45119a046ee1e893bed9ae1143e69e677816689379dcbba12151cdcf5a53a3e4"
+metafile = true
+
+[[files]]
+file = "mods/emuno.pw.toml"
+hash = "3fe8ab29c47d04dd0a80b3886534bfa56bfcab9a490dbfdc96c4516db8c477b3"
 metafile = true
 
 [[files]]
@@ -126,6 +145,11 @@ metafile = true
 [[files]]
 file = "mods/foxbox.pw.toml"
 hash = "43bf820b9d05944c55390061a0c75486824ab15ab75c2ce88e7a853e6bc7b8cd"
+metafile = true
+
+[[files]]
+file = "mods/gamemenuremovegfarb.pw.toml"
+hash = "769e07f03e65c6adb8708f4da6c476365b24aad10f943514d6bbd8b0f57ff327"
 metafile = true
 
 [[files]]
@@ -279,13 +303,28 @@ hash = "7d29724ac05ef8982475b92f0e77adf4a4830c249f0e8c1515a19777fbf05f09"
 metafile = true
 
 [[files]]
+file = "mods/reeses-sodium-options.pw.toml"
+hash = "44b0a2294e1693230308e53b529d671a0303e94b623ba2c2650cdf5760a5a335"
+metafile = true
+
+[[files]]
 file = "mods/regions-unexplored.pw.toml"
 hash = "132b94a20e3b95496a84bca92f83215c1ae9dcfa2cdc48262330ef57587c3e65"
 metafile = true
 
 [[files]]
+file = "mods/rmscore.pw.toml"
+hash = "498244e75e8f61e84db299e97d4c7de7b4419eff3e42236f755181a4bbe5342e"
+metafile = true
+
+[[files]]
 file = "mods/saplanting.pw.toml"
 hash = "88f46c9c462a0a84f3d10a78389210d225ea9edd8f22049a9f0e7f6ad294692f"
+metafile = true
+
+[[files]]
+file = "mods/sodium-extra.pw.toml"
+hash = "4e691c86059e755a026b8cae8cf0c66396dc39bf47b6c71980589101803ecd36"
 metafile = true
 
 [[files]]

--- a/mods/ctrl-q.pw.toml
+++ b/mods/ctrl-q.pw.toml
@@ -1,0 +1,13 @@
+name = "Ctrl Q"
+filename = "ctrlq-fabric-mc1.19.3+-1.9.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/Dxv5rpnB/versions/N4g6q0kL/ctrlq-fabric-mc1.19.3%2B-1.9.jar"
+hash-format = "sha1"
+hash = "937eaf746aa4e975a8cc2a6fec53d40b3049bc58"
+
+[update]
+[update.modrinth]
+mod-id = "Dxv5rpnB"
+version = "N4g6q0kL"

--- a/mods/dark-graph.pw.toml
+++ b/mods/dark-graph.pw.toml
@@ -1,0 +1,13 @@
+name = "Dark Graph"
+filename = "dark-graph-1.1.0.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/E7uiJ5bx/versions/bzhBMMB6/dark-graph-1.1.0.jar"
+hash-format = "sha1"
+hash = "8f70702ffacd780a40057724465c67b074da09a0"
+
+[update]
+[update.modrinth]
+mod-id = "E7uiJ5bx"
+version = "bzhBMMB6"

--- a/mods/emuno.pw.toml
+++ b/mods/emuno.pw.toml
@@ -1,0 +1,13 @@
+name = "EmuNO"
+filename = "emuno-1.1.0.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/RLrPqrNI/versions/Dkqzfeve/emuno-1.1.0.jar"
+hash-format = "sha1"
+hash = "01f741c3f6103899923e4421d0a1f253b74f61b7"
+
+[update]
+[update.modrinth]
+mod-id = "RLrPqrNI"
+version = "Dkqzfeve"

--- a/mods/gamemenuremovegfarb.pw.toml
+++ b/mods/gamemenuremovegfarb.pw.toml
@@ -1,0 +1,13 @@
+name = "Game Menu Remove GFARB"
+filename = "gamemenuremovegfarb-fabric-mc1.19.4-2.1.2.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/bKQclmIt/versions/RqkO2I7y/gamemenuremovegfarb-fabric-mc1.19.4-2.1.2.jar"
+hash-format = "sha1"
+hash = "34832dcf3cb85993c066a53a2d4a2190f191c10e"
+
+[update]
+[update.modrinth]
+mod-id = "bKQclmIt"
+version = "RqkO2I7y"

--- a/mods/reeses-sodium-options.pw.toml
+++ b/mods/reeses-sodium-options.pw.toml
@@ -1,0 +1,13 @@
+name = "Reese's Sodium Options"
+filename = "reeses_sodium_options-1.6.5+mc1.20.1-build.95.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/Bh37bMuy/versions/hCsMUZLa/reeses_sodium_options-1.6.5%2Bmc1.20.1-build.95.jar"
+hash-format = "sha1"
+hash = "49c68b22b9b4db4e1d3eaa3bdb6fdedd1faeba29"
+
+[update]
+[update.modrinth]
+mod-id = "Bh37bMuy"
+version = "hCsMUZLa"

--- a/mods/rmscore.pw.toml
+++ b/mods/rmscore.pw.toml
@@ -1,0 +1,13 @@
+name = "NoMoreScore"
+filename = "nomorescore-1.1.0.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/aRooc1Sw/versions/Pj3rvMce/nomorescore-1.1.0.jar"
+hash-format = "sha1"
+hash = "aaf82405b3ee3ebb819b303507d7693cd55e9d90"
+
+[update]
+[update.modrinth]
+mod-id = "aRooc1Sw"
+version = "Pj3rvMce"

--- a/mods/sodium-extra.pw.toml
+++ b/mods/sodium-extra.pw.toml
@@ -1,0 +1,13 @@
+name = "Sodium Extra"
+filename = "sodium-extra-0.5.1+mc1.20.1-build.112.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/PtjYWJkn/versions/80a0J5Cn/sodium-extra-0.5.1%2Bmc1.20.1-build.112.jar"
+hash-format = "sha1"
+hash = "74b6dce1ede645ffdecf1185fa05701cef68840d"
+
+[update]
+[update.modrinth]
+mod-id = "PtjYWJkn"
+version = "80a0J5Cn"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "7581e238083a9dfaa8a31d26669a9952472f6f757a63d7f3850f39182c1ed658"
+hash = "dd0d99e69353798967d41dd417905f4134ec2e8ed5683d8fe5379822ce9c3a83"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
Description: This PR adds some mods that would be useful for a better client experience including macOS players. This also adds a config for mod menu. Duplicate of https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/pull/48 with upstream changes.

The mods that were added are:
- [Ctrl Q](https://modrinth.com/mod/ctrl-q)
- [Dark Graph](https://modrinth.com/mod/dark-graph)
- [EmuNO](https://modrinth.com/mod/emuno)
- [Game Menu Remove GFARB](https://modrinth.com/mod/gamemenuremovegfarb)
- [Reese's Sodium Options](https://modrinth.com/mod/reeses-sodium-options)
- [NoMoreScore](https://modrinth.com/mod/rmscore)
- [Sodium Extra](https://modrinth.com/mod/sodium-extra)

All of these mods were tested to make sure they work with the modpack.