### PR TITLE
Add mods, update the README and fix a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unoffical Quilt SMP 3
+# Unofficial Quilt SMP 3
 
 This repo contains the packwiz files for the Unofficial Quilt SMP 3 modpack.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repo contains the packwiz files for the Unofficial Quilt SMP 3 modpack.
 
 ## How to download the packwiz / unsup pack on the Prism Launcher?
+
 1. Open Prism Launcher and click `Add Instance`.
 2. Go to Import tab and click `Browse`.
 3. Find where you downloaded the modpack and click open.

--- a/config/modmenu.json
+++ b/config/modmenu.json
@@ -3,7 +3,7 @@
   "count_libraries": true,
   "compact_list": false,
   "count_children": true,
-  "mods_button_style": "classic",
+  "mods_button_style": "replace_realms",
   "game_menu_button_style": "replace_bugs",
   "count_hidden_mods": true,
   "mod_count_location": "title_screen",

--- a/index.toml
+++ b/index.toml
@@ -14,7 +14,7 @@ hash = "42b8328d9c958aa8adca9a9fc62d0deb154e4a411ba55e984211f6e673ad2d58"
 
 [[files]]
 file = "config/modmenu.json"
-hash = "99e37f421f65527d18d572cdefbfaddc05073a4aacc9d0efe4adcbb2b619a661"
+hash = "e61694d0fad31bbdb05b48559dee527159e0c95700229b3e95a0790e11edae36"
 
 [[files]]
 file = "config/saplanting.json"
@@ -27,6 +27,11 @@ hash = "0445b912fda5f4517efc1ae723ad13add5b9a9d0f15ec21beb9e806cb7b988b2"
 [[files]]
 file = "config/tooltipscroll.json"
 hash = "b1eee945b3ee47f6fe7a189efdfa8aa0e4c20d088f04abb4a03907e15efae31a"
+
+[[files]]
+file = "mods/alloy-forgery.pw.toml"
+hash = "149062fec33cc9b361650d6aacbbb668381007e14ec6b1ef98fb7e4fe9c51685"
+metafile = true
 
 [[files]]
 file = "mods/arch-ex.pw.toml"
@@ -124,6 +129,11 @@ hash = "96933d7137dd25472c2057e093de87cf7f7d3c12aab36f17ae8b8a3d65c6623d"
 metafile = true
 
 [[files]]
+file = "mods/explosive-enhancement.pw.toml"
+hash = "38ed72cfb9405c7b40079e1cc6d335806a3fc0c7f98aee04a44adacdb5452ece"
+metafile = true
+
+[[files]]
 file = "mods/fabrication.pw.toml"
 hash = "8c3a4d0dacc0dc1194bc151d790f081d3178f3761c390bd9cc2ef33c16ef9e44"
 metafile = true
@@ -169,6 +179,11 @@ hash = "06a155cdcd720584f9a01544e6ddd9b20960532359e72183f5cf3565b46f23fd"
 metafile = true
 
 [[files]]
+file = "mods/groovyduvet.pw.toml"
+hash = "412139d37c023a7e50b7ab311be15a592f9173b91d456677cf144a8a48357d47"
+metafile = true
+
+[[files]]
 file = "mods/immediatelyfast.pw.toml"
 hash = "ca885ba80a295fe9729c9ef27e366911d8ec2467bcced404f08593ead37176b0"
 metafile = true
@@ -186,6 +201,11 @@ metafile = true
 [[files]]
 file = "mods/iris.pw.toml"
 hash = "e160cd9f6d5beb781af38f9b75b88002a5bd65daa566fb3fc3a1e1e036a4c229"
+metafile = true
+
+[[files]]
+file = "mods/jsonwrangler.pw.toml"
+hash = "b6a832c7f5cc8b6e91247f5becd90593a401adf89025e9dc492876a203db71b9"
 metafile = true
 
 [[files]]
@@ -214,6 +234,11 @@ hash = "2fbce6c9dc6eb7ec8cb0261e64113544b4eceab281b61dbf3f5dc7f138b10c6b"
 metafile = true
 
 [[files]]
+file = "mods/midnightlib.pw.toml"
+hash = "50149a97b2d959bfac8e1c377fdab49fc52f1439d004b1ac1c26a3a7f790e044"
+metafile = true
+
+[[files]]
 file = "mods/missing-wilds.pw.toml"
 hash = "8d8cd0f99d1c048a46d94512a5e1e79792491139553bd7fe1b6b0f884650672d"
 metafile = true
@@ -236,6 +261,16 @@ metafile = true
 [[files]]
 file = "mods/moonlight.pw.toml"
 hash = "4150435ec9e3a6e92d61d972df268771d13a7662f7f585326268b7b411f388e4"
+metafile = true
+
+[[files]]
+file = "mods/mysterypotions.pw.toml"
+hash = "25143cd318957ffb058cb3c9e3cbb0f6497e7a7bbe6dc575b8d5dfa56097e511"
+metafile = true
+
+[[files]]
+file = "mods/mythicmetals.pw.toml"
+hash = "3902d0e4b99082a481bdee3dc452f53300c66dcb5b98e710db6f162fa34ba7cd"
 metafile = true
 
 [[files]]
@@ -396,6 +431,11 @@ metafile = true
 [[files]]
 file = "mods/terrestria.pw.toml"
 hash = "1c43a497cc911474b50a0706b05f1e6040179f1443a59112f2c56157f12c7165"
+metafile = true
+
+[[files]]
+file = "mods/the-bumblezone-fabric.pw.toml"
+hash = "4fbf535c32ba6abd4b11ae1421573286b46f2168f40dc5945bde35f9ce0244e9"
 metafile = true
 
 [[files]]

--- a/mods/alloy-forgery.pw.toml
+++ b/mods/alloy-forgery.pw.toml
@@ -1,0 +1,13 @@
+name = "Alloy Forgery"
+filename = "alloy-forgery-2.0.22+1.20.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/jhl28YkY/versions/CDuKyCCF/alloy-forgery-2.0.22%2B1.20.jar"
+hash-format = "sha1"
+hash = "7f13357a70a8a04c0c2747e80b7fc9dbaf5801c1"
+
+[update]
+[update.modrinth]
+mod-id = "jhl28YkY"
+version = "CDuKyCCF"

--- a/mods/explosive-enhancement.pw.toml
+++ b/mods/explosive-enhancement.pw.toml
@@ -1,0 +1,13 @@
+name = "Explosive Enhancement"
+filename = "explosive-enhancement-1.2.1-1.20.x.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/OSQ8mw2r/versions/FJnk7qhP/explosive-enhancement-1.2.1-1.20.x.jar"
+hash-format = "sha1"
+hash = "585f8dadf74317aacf845de729647610ba1f58e2"
+
+[update]
+[update.modrinth]
+mod-id = "OSQ8mw2r"
+version = "FJnk7qhP"

--- a/mods/groovyduvet.pw.toml
+++ b/mods/groovyduvet.pw.toml
@@ -1,0 +1,13 @@
+name = "GroovyDuvet"
+filename = "groovyduvet-3.0.14-full.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/8tpeB2g5/versions/82HCO0We/groovyduvet-3.0.14-full.jar"
+hash-format = "sha1"
+hash = "7a893b897a8f83de37b7156fd8b348ee486c214c"
+
+[update]
+[update.modrinth]
+mod-id = "8tpeB2g5"
+version = "82HCO0We"

--- a/mods/jsonwrangler.pw.toml
+++ b/mods/jsonwrangler.pw.toml
@@ -1,0 +1,13 @@
+name = "JsonWrangler"
+filename = "jsonwrangler-quilt-1.20.1-1.0.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/XodEFO40/versions/sCzGPtXK/jsonwrangler-quilt-1.20.1-1.0.1.jar"
+hash-format = "sha1"
+hash = "b05e148ee48939af9f22c0876c277e482c82df5f"
+
+[update]
+[update.modrinth]
+mod-id = "XodEFO40"
+version = "sCzGPtXK"

--- a/mods/midnightlib.pw.toml
+++ b/mods/midnightlib.pw.toml
@@ -1,0 +1,13 @@
+name = "MidnightLib"
+filename = "midnightlib-quilt-1.4.1.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/codAaoxh/versions/3YykTkmJ/midnightlib-quilt-1.4.1.1.jar"
+hash-format = "sha1"
+hash = "51c3c548e3df53a486d8425f0b380779b985d3b6"
+
+[update]
+[update.modrinth]
+mod-id = "codAaoxh"
+version = "3YykTkmJ"

--- a/mods/mysterypotions.pw.toml
+++ b/mods/mysterypotions.pw.toml
@@ -1,0 +1,13 @@
+name = "Mystery Potions"
+filename = "mysterypotions-quilt-1.20.1-1.0.0.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/tfK7Fz9A/versions/wT4uumCK/mysterypotions-quilt-1.20.1-1.0.0.jar"
+hash-format = "sha1"
+hash = "01824c48ae7420dec0f960f951423440a85db7a6"
+
+[update]
+[update.modrinth]
+mod-id = "tfK7Fz9A"
+version = "wT4uumCK"

--- a/mods/mythicmetals.pw.toml
+++ b/mods/mythicmetals.pw.toml
@@ -1,0 +1,13 @@
+name = "Mythic Metals"
+filename = "mythicmetals-0.18.2+1.20.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/bAWzYNRd/versions/TIjrw9LW/mythicmetals-0.18.2%2B1.20.jar"
+hash-format = "sha1"
+hash = "767204647e5dc9dc0bc058bc90081bc86b6e261a"
+
+[update]
+[update.modrinth]
+mod-id = "bAWzYNRd"
+version = "TIjrw9LW"

--- a/mods/the-bumblezone-fabric.pw.toml
+++ b/mods/the-bumblezone-fabric.pw.toml
@@ -1,0 +1,13 @@
+name = "The Bumblezone - Quilt/Fabric"
+filename = "the_bumblezone-7.0.11+1.20.1-quilt.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/eA8SXqWL/versions/WFE0sBtf/the_bumblezone-7.0.11%2B1.20.1-quilt.jar"
+hash-format = "sha1"
+hash = "64894dfa7dec8076f59ac4edb1769a0d5ae66ad4"
+
+[update]
+[update.modrinth]
+mod-id = "eA8SXqWL"
+version = "WFE0sBtf"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6abf992bc0ed2eb133ba3c66b162272aac0537f3e09bb4499141baabd1d78c7d"
+hash = "89dc1b9582437cb8061592282d2616057110464ea51f94e47d7c22ae4d5751dd"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
Description: This PR adds mods that were tested from the Github Issue list. This also adds some fixes to the README and t the mod menu config so it replaces the realm button rather than being under it.

Mods that were added from the Github Issue List:

- Mythic Metals and Alloy Forgery (https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/issues/11)
- Explosive Enhancement (https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/issues/28)
- Mystery Potions (https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/issues/35)
- The Bumblezone (https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/issues/41)

I need your opinion, should we add ZsoltMolnarrr's "RPG Series" mods? As much as they look good, they have alot of dependancies as you commented on the relevant Github Issue (https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/issues/16).

I tested the mods and i have to say, they work pretty well with the pack with all the dependancies loaded and intergrates with some existing mods we have so, it is up to you if you want to include it. Let me know!