### PR TITLE
Add owo-lib, update to Quilt Loader 0.21.0 and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You can find the download link for the modpack [here](https://cdn.discordapp.com
 
 Here you can find the optional mods that you can add to the modpack for a better experience.
 
+[Amecs](https://modrinth.com/mod/amecs)
 [Nicer Skies](https://modrinth.com/mod/nicer-skies)
 
 ## Discussing the modpack

--- a/index.toml
+++ b/index.toml
@@ -289,6 +289,11 @@ hash = "23583083d03c8effa3dca4c17c7da2fcf57d653292b02898afe8d7029be6b0d7"
 metafile = true
 
 [[files]]
+file = "mods/owo-lib.pw.toml"
+hash = "28b3e0806647eb166e942cf6552993bb6d666949c53f0d51927bdfb063cb6cc4"
+metafile = true
+
+[[files]]
 file = "mods/patched.pw.toml"
 hash = "24362d3c0b327b2cc314380519df63e035f4386075672e4585b8f36b04d3380e"
 metafile = true

--- a/mods/owo-lib.pw.toml
+++ b/mods/owo-lib.pw.toml
@@ -1,0 +1,13 @@
+name = "oωo (owo-lib)"
+filename = "owo-lib-0.11.2+1.20.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/ccKDOlHs/versions/zyOBB7J4/owo-lib-0.11.2%2B1.20.jar"
+hash-format = "sha1"
+hash = "be88938ca5df78271e64bc9f85c3575754f33e2a"
+
+[update]
+[update.modrinth]
+mod-id = "ccKDOlHs"
+version = "zyOBB7J4"

--- a/pack.toml
+++ b/pack.toml
@@ -6,11 +6,11 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "89dc1b9582437cb8061592282d2616057110464ea51f94e47d7c22ae4d5751dd"
+hash = "05676d84d470fbf84830f31aae616adb9633937e3c765deb1c86a22e700790d4"
 
 [versions]
 minecraft = "1.20.1"
-quilt = "0.20.2"
+quilt = "0.21.0"
 
 [options]
 acceptable-game-versions = []


### PR DESCRIPTION
Description: This PR includes an addition of owow-lib which is required for multiple mods in the pack. This PR also updates the Quilt Loader to 0.21.0 and updates the README to include Amecs (https://github.com/woodiertexas/unofficial-quilt-smp-the-3rd/issues/18) as an optional mod.